### PR TITLE
Display courses ordered by id.

### DIFF
--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -3,7 +3,7 @@ class Api::CoursesController < Api::BaseController
   skip_before_action :verify_authenticity_token
 
   def index
-    render json: Course.all
+    render json: Course.order(:id).all
   end
 
   def show


### PR DESCRIPTION
On CoursesScreen, display courses ordered by id.

To test, try editing a course name. Before, the course would have moved down to the bottom (I think it was previously sorted on last modified, where last modified is last). Now, course order stays the same.