### PR TITLE
Casey/edit dream

### DIFF
--- a/app/controllers/api/teachers_controller.rb
+++ b/app/controllers/api/teachers_controller.rb
@@ -3,10 +3,9 @@ class Api::TeachersController < Api::BaseController
   def update
     @teacher = Teacher.find(params[:id])
 
-    if teacher_params.key?("dream_id")
-      puts "CHANGING DREAM ID"
-    else
-      puts "No dream id"
+    # Cannot update teacher dream_id if teacher already has courses
+    if teacher_params.key?("dream_id") && @teacher.courses.present?
+      return render_error_response(:forbidden, ["Cannot change dream ID. Courses are already linked to your account."])
     end
 
     if @teacher.update(teacher_params)

--- a/app/controllers/api/teachers_controller.rb
+++ b/app/controllers/api/teachers_controller.rb
@@ -1,37 +1,42 @@
 class Api::TeachersController < Api::BaseController
 
-    def update
-      @teacher = Teacher.find(params[:id])
+  def update
+    @teacher = Teacher.find(params[:id])
 
-      if @teacher.update(teacher_params)
-        render json: @teacher
-      else
-        error_response(@teacher)
-      end
+    if teacher_params.key?("dream_id")
+      puts "CHANGING DREAM ID"
+    else
+      puts "No dream id"
     end
 
-    def show
-      @teacher = Teacher.find(params[:id])
+    if @teacher.update(teacher_params)
       render json: @teacher
+    else
+      error_response(@teacher)
     end
+  end
 
-    def index
-      @teachers = Teacher.all
-      render json: @teachers
+  def show
+    @teacher = Teacher.find(params[:id])
+    render json: @teacher
+  end
+
+  def index
+    @teachers = Teacher.all
+    render json: @teachers
+  end
+
+  def destroy
+    @teacher = Teacher.find(params[:id])
+    if @teacher.destroy
+      render json: @teacher
+    else
+      error_response(@teacher)
     end
+  end
 
-    def destroy
-      @teacher = Teacher.find(params[:id])
-      if @teacher.destroy
-        render json: @teacher
-      else
-        error_response(@teacher)
-      end
+  private
+    def teacher_params
+      params.require(:teacher).permit(:first_name, :last_name, :dream_id, :email, :phone)
     end
-
-    private
-      def teacher_params
-        params.require(:teacher).permit(:first_name, :last_name, :dream_id, :email, :phone)
-      end
-
   end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -18,6 +18,6 @@ class Teacher < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_many :students
-  has_many :courses
+  has_and_belongs_to_many :courses
 	validates :first_name, :last_name, :dream_id, :email, :phone, presence: true
 end


### PR DESCRIPTION
Don't allow teachers to edit dream_id if courses exist (if no courses exist, that means no students exist, so only need to check courses)

I tested changing the ID when a teacher had courses (it didn't let me) and deleting all the courses in order to change the ID (this worked, and let me update the ID)

(Also fixed teacher-courses association -- can access teacher.courses now)

<img width="364" alt="screen shot 2017-11-27 at 7 25 16 pm" src="https://user-images.githubusercontent.com/10657390/33301126-e2ab9922-d3a8-11e7-89f0-0ac51d090ee0.png">
