### PR TITLE
Adds CanCanCan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem 'devise'
 
 gem 'rails-erd', require: false, group: :development
 
+gem 'cancancan', '~> 2.0'
+
+gem 'rb-readline'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.1.0)
+    cancancan (2.0.0)
     capybara (2.15.4)
       addressable
       mini_mime (>= 0.1.3)
@@ -153,6 +154,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -215,6 +217,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   annotate (~> 2.7.2)
   byebug
+  cancancan (~> 2.0)
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   devise
@@ -226,6 +229,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.4)
   rails-erd
+  rb-readline
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -1,4 +1,6 @@
 class Api::CoursesController < Api::BaseController
+  # TODO: Uncomment when auth_token is ready
+  # load_and_authorize_resource
 
   def index
     render json: Course.order(:id).all

--- a/app/controllers/api/teachers_controller.rb
+++ b/app/controllers/api/teachers_controller.rb
@@ -1,4 +1,6 @@
 class Api::TeachersController < Api::BaseController
+  # TODO: Uncomment when auth_token is ready
+  # load_and_authorize_resource
 
   def update
     @teacher = Teacher.find(params[:id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include CanCan::ControllerAdditions
   respond_to :json
 
   def not_found_response
@@ -23,6 +24,6 @@ class ApplicationController < ActionController::API
   end
 
   def current_ability
-    @current_ability ||= Ability.new(current_user)
+    @current_ability ||= ::Abilities::Ability.new(current_user)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,13 @@ class ApplicationController < ActionController::API
   def render_error_response(status, errors)
     render json: { errors: errors }, status: status
   end
+
+  # CanCanCan
+  def current_user
+    current_teacher
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user)
+  end
 end

--- a/app/models/abilities/ability.rb
+++ b/app/models/abilities/ability.rb
@@ -1,0 +1,32 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/abilities/ability.rb
+++ b/app/models/abilities/ability.rb
@@ -1,32 +1,41 @@
-class Ability
-  include CanCan::Ability
+module Abilities
+  class Ability
+    include CanCan::Ability
 
-  def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
-    #   user ||= User.new # guest user (not logged in)
-    #   if user.admin?
-    #     can :manage, :all
-    #   else
-    #     can :read, :all
-    #   end
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    def initialize(user)
+      # Define abilities for the passed in user here. For example:
+      #
+      #   user ||= User.new # guest user (not logged in)
+      #   if user.admin?
+      #     can :manage, :all
+      #   else
+      #     can :read, :all
+      #   end
+      #
+      # The first argument to `can` is the action you are giving the user
+      # permission to do.
+      # If you pass :manage it will apply to every action. Other common actions
+      # here are :read, :create, :update and :destroy.
+      #
+      # The second argument is the resource the user can perform the action on.
+      # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+      # class of the resource.
+      #
+      # The third argument is an optional hash of conditions to further filter the
+      # objects.
+      # For example, here the user can only update published articles.
+      #
+      #   can :update, Article, :published => true
+      #
+      # See the wiki for details:
+      # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+
+      if user.is_a? Teacher
+        return TeacherAbility.new(user)
+      else
+        # FIXME: If more users are added in the future change
+        return TeacherAbility.new(user)
+      end
+    end
   end
 end

--- a/app/models/abilities/teacher_ability.rb
+++ b/app/models/abilities/teacher_ability.rb
@@ -1,13 +1,34 @@
-class TeacherAbility
-  include CanCan::Ability
+module Abilities
+  class TeacherAbility
+    include CanCan::Ability
 
-  def initialize(teacher)
-    teacher ||= Teacher.new
+    def initialize(teacher)
+      teacher ||= Teacher.new
+      can :manage, Teacher, id: teacher.id
+      can :read, Teacher
 
-    can :manage, Teacher, id: teacher.id
-    can :read, Teacher
+      can [
+        :index,
+        :show,
+        :create,
+      ], CoursesTeacher
 
-    can :manage, Course do |course|
-      teacher.courses.include? course 
+      can :manage, Student do |student|
+        teacher.courses.exists? student.course_id
+      end
+
+      can :manage, Course do |course|
+        teacher.courses.include? course
+      end
+
+      can :manage, Attendance do |attendance|
+        teacher.courses.exists? attendance.course_id
+      end
+
+      can :manage, Session do |session|
+        teacher.courses.exists? sessions.course_id
+      end
     end
+
+  end
 end

--- a/app/models/abilities/teacher_ability.rb
+++ b/app/models/abilities/teacher_ability.rb
@@ -1,0 +1,13 @@
+class TeacherAbility
+  include CanCan::Ability
+
+  def initialize(teacher)
+    teacher ||= Teacher.new
+
+    can :manage, Teacher, id: teacher.id
+    can :read, Teacher
+
+    can :manage, Course do |course|
+      teacher.courses.include? course 
+    end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,7 +11,10 @@
 
 class Course < ApplicationRecord
   has_many :students
-  has_and_belongs_to_many :teachers
+
+  has_many :courses_teachers
+  has_many :teachers, through: :courses_teachers
+  
   has_many :attendances
   has_many :sessions, :dependent => :destroy
 end

--- a/app/models/courses_teacher.rb
+++ b/app/models/courses_teacher.rb
@@ -1,0 +1,4 @@
+class CoursesTeacher < ApplicationRecord
+  belongs_to :course
+  belongs_to :teacher 
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -17,6 +17,9 @@ class Teacher < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_and_belongs_to_many :courses
+
+  has_many :courses_teachers
+  has_many :courses, through: :courses_teachers
+
 	validates :first_name, :last_name, :dream_id, :email, :phone, presence: true
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,8 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+$teachers = []
+$courses = []
 
 def make_teachers
   1.upto(5) do |n|
@@ -17,8 +19,7 @@ def make_teachers
       password_confirmation: "password",
       phone: Faker::PhoneNumber.cell_phone.gsub(/-/, ''),
     )
-    teacher.id = n
-    teacher.save
+    $teachers << teacher
   end
 end
 
@@ -27,17 +28,26 @@ def make_courses
   1.upto(10) do |n|
     course = Course.create(
       title: Faker::Educator.course,
-      teacher_id1: n % 4 + 1,
-      teacher_id2: n % 4 + 2,
+      teacher_id1: n % ($teachers.length - 1) + 1,
+      teacher_id2: n % ($teachers.length - 1) + 2,
       start_date: six_months_ago.advance(months: n),
       end_date: six_months_ago.advance(months: n + 2),
       is_active: Faker::Boolean.boolean,
     )
-    course.teachers << Teacher.find(course.teacher_id1)
-    course.teachers << Teacher.find(course.teacher_id2)
+    $courses << course
+  end
+end
 
-    course.id = n
-    course.save
+def make_teacher_courses
+  $courses.each do |course|
+    CoursesTeacher.create(
+      course_id: course.id,
+      teacher_id: course.id % ($teachers.length - 1) + 1,
+    )
+    CoursesTeacher.create(
+      course_id: course.id,
+      teacher_id: course.id % ($teachers.length - 1) + 2, 
+    )
   end
 end
 
@@ -81,5 +91,6 @@ end
 
 make_teachers
 make_courses
+make_teacher_courses
 make_sessions
 make_students

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,8 +83,6 @@ def make_students
         course_id: n,
         dream_id: (n-1) * 5 + m
       )
-      student.id = (n-1) * 5 + m
-      student.save
     end
   end
 end

--- a/test/fixtures/courses_teachers.yml
+++ b/test/fixtures/courses_teachers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/courses_teacher_test.rb
+++ b/test/models/courses_teacher_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoursesTeacherTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
@florencelau 
@vanesng 

There are are some issues right now with how we're authenticating users from mobile using Devise. Because the rails app is API-only we can't store cookies in a browser in order to authenticate users (so right now `teacher_signed_in?` is `false` everywhere for API requests since the server cannot confirm the identity of API requests coming from the mobile side. A solution for this would be to use auth tokens along with Devise which would work something like this:

1. When mobile user logs in w/username+password and creates a new Devise session an auth token is securely generated and stored in the user table. 
2. Then the server returns the auth token to the user in the response, and this has to be persisted on the mobile side somehow
3. When the mobile user tries to send another API request like `GET /courses` then it will also need to send an authorization header with the auth token retrieved from storage

I would suggest using something like https://github.com/lynndylanhurley/devise_token_auth, and also look at https://github.com/plataformatec/devise/wiki/How-To:-Simple-Token-Authentication-Example. 

Replate business/marketplace also has a working implementation I think which is done manually, so if you want to ask the people involved there that would also be a good idea. 

This is all preventing CanCanCan from working right now since the `current_teacher` object will not exist until we can pass these tokens back to the server to authenticate. 

Let me know if y'all have any questions about this! This can be merged now thought idt it will affect any functionality. 